### PR TITLE
feat: add success message and restart option to service config edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,14 +211,40 @@ You can pull the source code to compile the binary executable file yourself, or 
 
 **Note:** Please make sure that executable permissions have been set before running. If there are no executable permissions, you can set them through the `chmod +x go-gin` command.
 
-## Run as Service
+### Run as Service
 
-### Linux (systemd)
+#### Linux (systemd)
 
 In Linux, services are managed through Systemd. You can use the following commands to install, start, stop, restart, log, and view the status of services, etc.
 
 ```bash
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/funnyzak/go-gin/main/script/install.sh)"
+```
+
+#### Windows
+
+Service on Windows can be implemented using Task Scheduler. You can use the following steps to install and start the service.
+
+1. Dwnload the binary executable file of the corresponding system architecture from the [releases](https://github.com/funnyzak/go-gin/releases) page or [GitHub Actions](https://github.com/funnyzak/go-gin/actions) page, and unzip it to the `C:\go-gin` directory.
+2. Download [install.ps1](https://raw.githubusercontent.com/funnyzak/go-gin/main/script/install.ps1) file to the `C:\go-gin` directory and rename it to `go-gin.ps1`.
+3. Download [config.example.ps1](https://raw.githubusercontent.com/funnyzak/go-gin/main/config.example.yaml) file to the `C:\go-gin` directory and rename it to `config.yaml`, and update the values.
+
+Finally, run the following command to start the service:
+
+```powershell
+cd C:\go-gin
+.\go-gin.ps1 enable
+```
+
+The following are all the commands supported by the script:
+
+```powershell
+./go-gin.ps1 enable  # Enable and start the service
+./go-gin.ps1 disable # Disable and stop the service
+./go-gin.ps1 start   # Start the service
+./go-gin.ps1 stop    # Stop the service
+./go-gin.ps1 restart # Restart the service
+./go-gin.ps1 status  # View the service status
 ```
 
 ## License

--- a/script/install.ps1
+++ b/script/install.ps1
@@ -86,5 +86,12 @@ if ($args[0] -eq "enable") {
         }
     }
 } else {
-    Write-Host "Please specify 'enable' or 'disable'."
+    Write-Host "Usage: go-gin.ps1 [install|uninstall|enable|disable|start|stop|restart|status]"
+    Write-Host "  enable   - Enable the service."
+    Write-Host "  disable  - Disable the service."
+    Write-Host "  start    - Start the service."
+    Write-Host "  stop     - Stop the service."
+    Write-Host "  restart  - Restart the service."
+    Write-Host "  status   - Show the status of the service."
+    exit
 }

--- a/script/install.sh
+++ b/script/install.sh
@@ -59,7 +59,7 @@ start_check() {
 
     ping_check
 
-    GG_LATEST_VERSION=$(get_service_version)
+    GG_LATEST_VERSION=$(get_service_latest_version)
     if [ -z "${GG_LATEST_VERSION}" ]; then
         echo -e "${red}ERROR${plain}: Get ${GG_SERVICE_NAME} latest version failed."
         exit 1
@@ -353,7 +353,7 @@ download_service_app() {
   chmod +x ${GG_SERVICE_PATH}
 }
 
-get_service_version() {
+get_service_latest_version() {
   local latest_version=$(curl -s ${GG_RELEASES_DATA_URL} | grep "tag_name" | head -n 1 | awk -F '"' '{print $4}')
   if [ -n "${latest_version}" ]; then
     echo "${latest_version}"

--- a/script/install.sh
+++ b/script/install.sh
@@ -309,6 +309,10 @@ edit_service_config() {
     echo -e "${red}ERROR${plain}: No editor found."
     return 1
   fi
+  echo -e "${green}${GG_SERVICE_NAME}${plain} service config edit success."
+  if confirm "Do you want to restart ${GG_SERVICE_NAME} service?"; then
+    execute_funcs "service_action restart"
+  fi
 
   if [[ $# == 0 ]]; then
     before_show_menu


### PR DESCRIPTION
This pull request adds a success message and restart option to the service config edit functionality. It also updates the get_service_version function to get_service_latest_version. Additionally, it updates the README.md and install.ps1 scripts for running the service on Linux and Windows.